### PR TITLE
Update MySqlConnector to 1.2.0

### DIFF
--- a/src/Paradigm.ORM.Data.MySql/MySqlDatabaseCommand.Async.cs
+++ b/src/Paradigm.ORM.Data.MySql/MySqlDatabaseCommand.Async.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Paradigm.ORM.Data.Database;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Paradigm.ORM.Data.Exceptions;
 
 namespace Paradigm.ORM.Data.MySql

--- a/src/Paradigm.ORM.Data.MySql/MySqlDatabaseCommand.cs
+++ b/src/Paradigm.ORM.Data.MySql/MySqlDatabaseCommand.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using Paradigm.ORM.Data.Converters;
 using Paradigm.ORM.Data.Database;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Paradigm.ORM.Data.Exceptions;
 
 namespace Paradigm.ORM.Data.MySql

--- a/src/Paradigm.ORM.Data.MySql/MySqlDatabaseConnector.cs
+++ b/src/Paradigm.ORM.Data.MySql/MySqlDatabaseConnector.cs
@@ -11,7 +11,7 @@ using Paradigm.ORM.Data.Extensions;
 using Paradigm.ORM.Data.MySql.CommandBuilders;
 using Paradigm.ORM.Data.MySql.Converters;
 using Paradigm.ORM.Data.MySql.Schema;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Paradigm.ORM.Data.Logging;
 
 namespace Paradigm.ORM.Data.MySql

--- a/src/Paradigm.ORM.Data.MySql/MySqlDatabaseReader.cs
+++ b/src/Paradigm.ORM.Data.MySql/MySqlDatabaseReader.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using Paradigm.ORM.Data.Database;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Paradigm.ORM.Data.MySql
 {

--- a/src/Paradigm.ORM.Data.MySql/MySqlDatabaseTransaction.cs
+++ b/src/Paradigm.ORM.Data.MySql/MySqlDatabaseTransaction.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Paradigm.ORM.Data.Database;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Paradigm.ORM.Data.MySql
 {

--- a/src/Paradigm.ORM.Data.MySql/Paradigm.ORM.Data.MySql.csproj
+++ b/src/Paradigm.ORM.Data.MySql/Paradigm.ORM.Data.MySql.csproj
@@ -6,7 +6,7 @@
         <PackageProjectUrl>http://www.paradigm.net.co/</PackageProjectUrl>
         <Copyright>Miracle Devs</Copyright>
         <Description>Paradigm ORM MySql Connector library.</Description>
-        <PackageLicenseUrl>https://github.com/MiracleDevs/Paradigm.ORM/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIconUrl>https://avatars2.githubusercontent.com/u/8192926</PackageIconUrl>
         <RepositoryUrl>https://github.com/MiracleDevs/Paradigm.ORM.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MySqlConnector" Version="0.56.0" />
+        <PackageReference Include="MySqlConnector" Version="1.2.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: https://github.com/mysql-net/MySqlConnector/issues/824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.